### PR TITLE
Update textlint-rule-no-exclamation-question-mark

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.1.1",
     "textlint-rule-no-doubled-joshi": "^3.7.2",
     "textlint-rule-no-dropping-the-ra": "^1.1.3",
-    "textlint-rule-no-exclamation-question-mark": "^1.0.2",
+    "textlint-rule-no-exclamation-question-mark": "^1.1.0",
     "textlint-rule-no-hankaku-kana": "^1.0.2",
     "textlint-rule-no-mix-dearu-desumasu": "^4.0.1",
     "textlint-rule-no-nfd": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,13 +4157,14 @@ textlint-rule-no-dropping-the-ra@^1.1.3:
     kuromojin "^2.0.0"
     textlint-rule-helper "^2.1.1"
 
-textlint-rule-no-exclamation-question-mark@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/textlint-rule-no-exclamation-question-mark/-/textlint-rule-no-exclamation-question-mark-1.0.2.tgz#f3d812cfbaddc8224ca497d9b38b70dac554891c"
-  integrity sha1-89gSz7rdyCJMpJfZs4tw2sVUiRw=
+textlint-rule-no-exclamation-question-mark@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/textlint-rule-no-exclamation-question-mark/-/textlint-rule-no-exclamation-question-mark-1.1.0.tgz#5d6cf9bba6111c9619da91a3fff7c080847420b0"
+  integrity sha512-FcBH3uH2qp5VG7I9LKwolUCcPigONcsdam1JhAFPcu10YZNYX0r1l2y9Hzg+E4+1fXLgtGyiObWwfsfelTx8Bw==
   dependencies:
-    match-index "^1.0.1"
-    textlint-rule-helper "^1.1.5"
+    "@textlint/regexp-string-matcher" "^1.1.0"
+    match-index "^1.0.3"
+    textlint-rule-helper "^2.1.1"
 
 textlint-rule-no-hankaku-kana@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
`textlint-rule-no-exclamation-question-mark` v1.1.0がリリースされたのでアップデートします。