### PR TITLE
CI: add snapshot release

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,0 +1,32 @@
+name: "Canary Release@next"
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install Dependencies
+        run: yarn install
+      - name: "Release @next"
+        id: changesets
+        uses: changesets/action@master
+        with:
+          version: yarn changeset version --snapshot
+          publish: yarn changeset publish --no-git-tag --snapshot --tag next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.SHARED_BOT_NPM_TOKEN }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
 name: test
-on: [push, pull_request]
+on: [ push, pull_request ]
 env:
   CI: true
 jobs:
   test:
     name: "Test on Node.js ${{ matrix.node_version }}"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12.x, 14.x]
+        node_version: [ 14, 16, 18 ]
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
```
npm install textlint-rule-preset-ja-technical-writing@next
```

で常に最新版がインストールできるようになる。



fix #115 