### PR TITLE
actions/checkoutのバージョンコメントを厳密にする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         node_version: [ 16, 18, 20 ]
     steps:
       - name: checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: setup Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Actionsのバージョンコメントを曖昧な形で記述していると、renovateによるマイナー・パッチアップデートのPRでバージョンが記載されないので分かりづらいです: https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing/pull/160
そのため、 `actions/checkout` のバージョンコメントを厳密にすることで、renovateによるアップデートPRでバージョンが記載されるようにします。