### PR TITLE
CI test: Node.js 22対応

### DIFF
--- a/.changeset/proud-lions-tease.md
+++ b/.changeset/proud-lions-tease.md
@@ -1,0 +1,5 @@
+---
+"textlint-rule-preset-ja-technical-writing": patch
+---
+
+Node.js 16のサポートを終了しました

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [ 16, 18, 20 ]
+        node_version: [ 18, 20, 22 ]
     steps:
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v4
         with:
-          node_version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node_version }}
       - name: Install
         run: yarn install
       - name: Test


### PR DESCRIPTION
CI `test` でNode.js 22をテストするようにします。
また、EOLになっているNode.js 16のオミットと `actions/setup-node` のNode.jsのバージョン指定のパラメータの修正を行います。